### PR TITLE
Tell upstream servers not to buffer

### DIFF
--- a/server.php
+++ b/server.php
@@ -2,6 +2,7 @@
 #error_reporting(E_ALL);
 header('Content-Type: text/event-stream');
 header('Cache-Control: no-cache');
+header('X-Accel-Buffering: no');
 date_default_timezone_set('America/Los_Angeles');
 include('allmon.inc.php');
 


### PR DESCRIPTION
Some web servers like to buffer responses from scripts (I'm looking at you nginx). 

This PR adds a header to the server.php file that tells those servers to not do that. 

See: https://www.jeffgeerling.com/blog/2016/streaming-php-disabling-output-buffering-php-apache-nginx-and-varnish

